### PR TITLE
omit --save flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Skyscanner's public API for Node.js.
 ## Install
 
 ```sh
-$ npm install --save skyscanner
+$ npm install skyscanner
 ```
 
 


### PR DESCRIPTION
saving node-skyscanner as a dependency is not a requirement so the --save flag should be omitted since this is more a feature of npm and not something necessary in order to install the module. only time flag should be put in install instructions is when the module needs to be installed globally.
